### PR TITLE
Various fixes for osgEarth

### DIFF
--- a/src/applications/osgearth_boundarygen/BoundaryUtil.cpp
+++ b/src/applications/osgearth_boundarygen/BoundaryUtil.cpp
@@ -157,7 +157,7 @@ osg::Vec3dArray* BoundaryUtil::findHull(osg::Vec3dArray& points)
       continue;
     }
 
-    if (isLeft((*sorted)[minmin], (*sorted)[maxmin], (*sorted)[i]) > 0 && i < maxmin)
+    if (i < maxmin && isLeft((*sorted)[minmin], (*sorted)[maxmin], (*sorted)[i]) > 0)
       continue;  // ignore (*sorted)[i] above the lower line.  NOTE: Differs from original CH algorithm in that it keeps collinear points
 
     while (top > 0)  // there are at least 2 points on the stack
@@ -207,7 +207,7 @@ osg::Vec3dArray* BoundaryUtil::findHull(osg::Vec3dArray& points)
       continue;
     }
 
-    if (isLeft((*sorted)[maxmax], (*sorted)[minmax], (*sorted)[i]) > 0 && i > minmax)
+    if (i > minmax && isLeft((*sorted)[maxmax], (*sorted)[minmax], (*sorted)[i]) > 0)
       continue;  // ignore (*sorted)[i] below the upper line. NOTE: Differs from original CH algorithm in that it keeps collinear points
 
     while (top > bot)  // at least 2 points on the upper stack

--- a/src/applications/osgearth_clamp/osgearth_clamp.cpp
+++ b/src/applications/osgearth_clamp/osgearth_clamp.cpp
@@ -61,7 +61,7 @@ struct App
     std::string attrName;
     bool verbose;
 
-    App() : verbose(true) { }
+    App() : verbose(true), map(NULL) { }
 
     int open(int argc, char** argv)
     {

--- a/src/applications/osgearth_exportgroundcover/osgearth_exportgroundcover.cpp
+++ b/src/applications/osgearth_exportgroundcover/osgearth_exportgroundcover.cpp
@@ -64,7 +64,7 @@ struct App
     Threading::Lockable<std::queue<FeatureList*> > outputQueue;
     Threading::Event gate;
 
-    App() { }
+    App() : gclayer(NULL) { }
 
     int open(int argc, char** argv)
     {

--- a/src/applications/osgearth_magnify/osgearth_magnify.cpp
+++ b/src/applications/osgearth_magnify/osgearth_magnify.cpp
@@ -50,9 +50,12 @@ struct App
     ui::HSliderControl* _magSlider;
     bool _useLODScale;
 
-    App()
+    App() :
+       _mainView(NULL),
+       _magView(NULL),
+       _magSlider(NULL),
+       _useLODScale(true)
     {
-        _useLODScale = true;
     }
 
     float computeRangeScale()

--- a/src/osgEarth/EarthManipulator
+++ b/src/osgEarth/EarthManipulator
@@ -116,7 +116,7 @@ namespace osgEarth { namespace Util
         };
 
         struct OSGEARTH_EXPORT ActionOption {
-            ActionOption() { }
+            ActionOption() : _option(0) { }
             ActionOption( int option, bool value ) : _option(option), _bool_value(value) { }
             ActionOption( int option, int value ) : _option(option), _int_value(value) { }
             ActionOption( int option, double value ) : _option(option), _dbl_value(value) { }

--- a/src/osgEarth/EarthManipulator.cpp
+++ b/src/osgEarth/EarthManipulator.cpp
@@ -597,7 +597,13 @@ _continuous_dx          ( rhs._continuous_dx ),
 _continuous_dy          ( rhs._continuous_dy ),
 _last_continuous_action_time ( rhs._last_continuous_action_time ),
 _single_axis_x          (rhs._single_axis_x),
-_single_axis_y          (rhs._single_axis_y)
+_single_axis_y          (rhs._single_axis_y),
+_setVPAccel             (rhs._setVPAccel),
+_setVPAccel2            (rhs._setVPAccel2),
+_lastTetherMode         (rhs._lastTetherMode),
+_homeViewpointDuration  (rhs._homeViewpointDuration),
+_lastKnownVFOV          (rhs._lastKnownVFOV),
+_userWillCallUpdateCamera(rhs._userWillCallUpdateCamera)
 {
     reinitialize();
 }

--- a/src/osgEarth/ExampleResources.cpp
+++ b/src/osgEarth/ExampleResources.cpp
@@ -365,7 +365,7 @@ MapNodeHelper::load(osg::ArgumentParser&   args,
     }
 
     // a root node to hold everything:
-    osg::Group* root = new osg::Group();
+    osg::ref_ptr<osg::Group> root = new osg::Group();
 
     root->addChild( node );
     

--- a/src/osgEarth/GeoData.cpp
+++ b/src/osgEarth/GeoData.cpp
@@ -1618,41 +1618,46 @@ DataExtent::DataExtent() :
 }
 
 DataExtent::DataExtent(const GeoExtent& extent, unsigned minLevel, unsigned maxLevel, const std::string &description) :
-GeoExtent(extent)
+GeoExtent(extent),
+_minLevel(minLevel),
+_maxLevel(maxLevel),
+_description(description)
 {
-    _minLevel = minLevel;
-    _maxLevel = maxLevel;
-    _description = description;
+   //NOP
 }
 
 DataExtent::DataExtent(const GeoExtent& extent, const std::string &description) :
 GeoExtent(extent),
-_minLevel( 0 ),
-_maxLevel( 0 )
+_minLevel(0),
+_maxLevel(0),
+_description(description)
 {
-    _description = description;
+   //NOP
 }
 
 DataExtent::DataExtent(const GeoExtent& extent, unsigned minLevel,  unsigned maxLevel) :
-GeoExtent(extent)
+GeoExtent(extent),
+_minLevel(minLevel),
+_maxLevel(maxLevel)
 {
-    _minLevel = minLevel;
-    _maxLevel = maxLevel;
+   //NOP
 }
 
 DataExtent::DataExtent(const GeoExtent& extent, unsigned minLevel) :
 GeoExtent(extent),
-_maxLevel( 25 )
+_minLevel(minLevel),
+_maxLevel(25)
 {
-    _minLevel = minLevel;
+   //NOP
 }
 
 DataExtent::DataExtent(const GeoExtent& extent, unsigned minLevel, const std::string &description) :
 GeoExtent(extent),
-_maxLevel( 0 )
+_minLevel(minLevel),
+_maxLevel(25),
+_description(description)
 {
-    _minLevel = minLevel;
-    _description = description;
+   //NOP
 }
 
 DataExtent::DataExtent(const GeoExtent& extent ) :

--- a/src/osgEarth/HeightFieldUtils.cpp
+++ b/src/osgEarth/HeightFieldUtils.cpp
@@ -243,6 +243,8 @@ HeightFieldUtils::getHeightAtPixel(const osg::HeightField* hf, double c, double 
         result = (n.x() * (c - v0.x()) + n.y() * (r - v0.y())) / -n.z() + v0.z();
         break;
     }
+    //    case INTERP_TRIANGULATE:
+    //    case INTERP_CUBICSPLINE:
     }
 
     return result;

--- a/src/osgEarth/ImageMosaic.cpp
+++ b/src/osgEarth/ImageMosaic.cpp
@@ -27,9 +27,9 @@ using namespace osgEarth::Util;
 
 /***************************************************************************/
 
-TileImage::TileImage(osg::Image* image, const TileKey& key)
+TileImage::TileImage(osg::Image* image, const TileKey& key) :
+_image(image)
 {
-    _image = image;
     key.getExtent().getBounds(_minX, _minY, _maxX, _maxY);
     key.getTileXY(_tileX, _tileY);
 }

--- a/src/osgEarth/InstanceCloud.cpp
+++ b/src/osgEarth/InstanceCloud.cpp
@@ -51,7 +51,17 @@ InstanceCloud::InstancingData::InstancingData() :
     commands(NULL),
     points(NULL),
     numTilesAllocated(0u),
-    ssboOffsetAlignment(-1)
+    ssboOffsetAlignment(-1),
+    contextID(0u),
+    commandBufferSize(0),
+    pointsBuffer(0u),
+    renderBufferTileSize(0),
+    numX(0u),
+    numY(0u),
+    tileToDraw(0u),
+    numIndices(0u),
+    mode(GL_PATCHES),
+    dataType(GL_UNSIGNED_SHORT)
 {
     // polyfill for pre-OSG 3.6 support
     osg::setGLExtensionFuncPtr(_glBufferStorage, "glBufferStorage", "glBufferStorageARB");
@@ -147,7 +157,6 @@ InstanceCloud::InstancingData::releaseGLObjects(osg::State* state) const
 
     commandBuffer = NULL;
     renderBuffer = NULL;
-    numTilesAllocated = 0;
 }
 
 InstanceCloud::InstanceCloud()
@@ -216,11 +225,6 @@ InstanceCloud::allocateGLObjects(osg::RenderInfo& ri, unsigned numTiles)
 void
 InstanceCloud::preCull(osg::RenderInfo& ri)
 {
-   if (!_data.commandBuffer)
-   {
-      return;
-   }
-
     osg::GLExtensions* ext = ri.getState()->get<osg::GLExtensions>();
 
     // Reset all the instance counts to zero by copying the empty
@@ -273,11 +277,6 @@ InstanceCloud::Renderer::Renderer(InstancingData* data) :
 void
 InstanceCloud::Renderer::drawImplementation(osg::RenderInfo& ri, const osg::Drawable* drawable) const
 {
-   if (!_data->commandBuffer)
-   {
-      return;
-   }
-
     osg::State& state = *ri.getState();
 
     osg::GLExtensions* ext = state.get<osg::GLExtensions>();

--- a/src/osgEarth/JsonUtils
+++ b/src/osgEarth/JsonUtils
@@ -485,7 +485,7 @@ namespace osgEarth { namespace Util { namespace Json
 # endif
       } value_;
       ValueType type_ : 8;
-      int allocated_ : 1;     // Notes: if declared as bool, bitfield is useless.
+      unsigned int allocated_ : 1;     // Notes: if declared as bool, bitfield is useless.
 # ifdef JSON_VALUE_USE_INTERNAL_MAP
       unsigned int itemIsUsed_ : 1;      // used by the ValueInternalMap container.
       int memberNameIsStatic_ : 1;       // used by the ValueInternalMap container.

--- a/src/osgEarth/Layer.cpp
+++ b/src/osgEarth/Layer.cpp
@@ -107,7 +107,9 @@ _revision(0u)
 
 Layer::Layer(Layer::Options* optionsPtr) :
 _options(optionsPtr? optionsPtr : &_optionsConcrete),
-_revision(0u)
+_revision(0u),
+_uid(0),
+_renderType(RENDERTYPE_NONE)
 {
     // init() will be called by base class
 }

--- a/src/osgEarth/Locators
+++ b/src/osgEarth/Locators
@@ -58,7 +58,6 @@ namespace osgEarth { namespace Util
     protected:
         osg::Matrixd _transform;
         osg::Matrixd _inverse;
-        double _x0, _y0, _x1, _y1;
         osg::ref_ptr<const SpatialReference> _srs;
     };
 } }

--- a/src/osgEarth/OGRFeatureSource.cpp
+++ b/src/osgEarth/OGRFeatureSource.cpp
@@ -213,7 +213,8 @@ OGR::OGRFeatureCursor::OGRFeatureCursor(OGRLayerH resultSetHandle, const Feature
     _spatialFilter(0L),
     _chunkSize(500),
     _nextHandleToQueue(0L),
-    _resultSetEndReached(false)
+    _resultSetEndReached(false),
+    _rewindPolygons(false)
 {
     OGR_SCOPED_LOCK;
 

--- a/src/osgEarth/SpatialReference
+++ b/src/osgEarth/SpatialReference
@@ -173,7 +173,7 @@ namespace osgEarth
 
         /** uniquely identifies an SRS. */
         struct Key {
-            Key() { }
+            Key() : hash(0) { }
             Key(const std::string& h, const std::string& v) : 
                 horiz(h), horizLower(toLower(h)), vert(v), vertLower(toLower(v))
             {

--- a/src/osgEarth/Style.cpp
+++ b/src/osgEarth/Style.cpp
@@ -58,13 +58,17 @@ _uri     ( rhs._uri )
 Style&
 Style::operator = ( const Style& rhs )
 {
-    _name = rhs._name;
-    _origType = rhs._origType;
-    _origData = rhs._origData;
-    _uri = rhs._uri;
-    _symbols.clear();
-    copySymbols(rhs);
-    return *this;
+   if (this != &rhs)
+   {
+      _name = rhs._name;
+      _origType = rhs._origType;
+      _origData = rhs._origData;
+      _uri = rhs._uri;
+      _symbols.clear();
+      copySymbols(rhs);
+   }
+
+   return *this;
 }
 
 void Style::addSymbol(Symbol* symbol)

--- a/src/osgEarth/TDTiles.cpp
+++ b/src/osgEarth/TDTiles.cpp
@@ -984,11 +984,8 @@ bool ThreeDTileNode::unloadContent()
 
     if (_content.valid())
     {
-        if (_content.valid())
-        {
-            _content->releaseGLObjects();
-            _content = 0;
-        }
+        _content->releaseGLObjects();
+        _content = 0;
     }
 
     _firstVisit = true;

--- a/src/osgEarth/TileRasterizer.cpp
+++ b/src/osgEarth/TileRasterizer.cpp
@@ -71,7 +71,9 @@ TileRasterizer::RenderOperation::RenderOperation(osg::Node* node, const GeoExten
     _node(node),
     _extent(extent),
     _renderData(renderData),
-    _pass(0)
+    _pass(0),
+    _async(false),
+    _pbo(0)
 {
     //nop
 }

--- a/src/osgEarth/WMS.cpp
+++ b/src/osgEarth/WMS.cpp
@@ -433,6 +433,7 @@ WMS::Driver::Driver(const WMS::WMSImageLayerOptions& myOptions,
     _sequence = sequence;
     _options = &myOptions;
     _readOptions = readOptions;
+    _isPlaying = false;
 }
 
 bool

--- a/src/osgEarth/WindLayer.cpp
+++ b/src/osgEarth/WindLayer.cpp
@@ -128,6 +128,7 @@ namespace
 
         void setupPerCameraState(const osg::Camera* camera);
         void drawImplementation(osg::RenderInfo& ri) const;
+        // base class has: compileGLObjects(RenderInfo& renderInfo), correct override?
         void compileGLObjects(osg::RenderInfo& ri, DrawState& ds) const;
         void releaseGLObjects(osg::State* state) const;
         void resizeGLObjectBuffers(unsigned maxSize);

--- a/src/osgEarthAerodromes/AerodromeFactory.cpp
+++ b/src/osgEarthAerodromes/AerodromeFactory.cpp
@@ -400,6 +400,7 @@ void AerodromeFactory::createBoundaryNodes(BoundaryFeatureOptions boundaryOpts, 
 
         // create new node and add to parent AerodromeNode
         aerodrome->setBoundary(new BoundaryNode(boundaryOpts, aerodrome->icao(), f));
+        // While loop run once?
         break;
     }
 }

--- a/src/osgEarthBuildings/BuildingLayer.cpp
+++ b/src/osgEarthBuildings/BuildingLayer.cpp
@@ -88,8 +88,8 @@ BuildingLayer::openImplementation()
         _catalog = new BuildingCatalog();
         if (_catalog->load(options().buildingCatalog().get(), getReadOptions(), 0L) == false)
         {
-            return Status(Status::ResourceUnavailable, "Cannot open building catalog");
             _catalog = 0L;
+            return Status(Status::ResourceUnavailable, "Cannot open building catalog");
         }
     }
     else

--- a/src/osgEarthDrivers/engine_rex/DrawTileCommand
+++ b/src/osgEarthDrivers/engine_rex/DrawTileCommand
@@ -106,7 +106,10 @@ namespace osgEarth { namespace REX
             _drawCallback(0L),
             _drawPatch(false),
             _range(0.0f),
-            _layerOrder(INT_MAX){ }
+            _layerOrder(INT_MAX),
+			_tile(NULL),
+			_key(NULL),
+			_tileRevision(0) { }
 
         virtual void accept(osg::PrimitiveFunctor& functor) const;
         virtual void accept(osg::PrimitiveIndexFunctor& functor) const;

--- a/src/osgEarthDrivers/engine_rex/LayerDrawable.cpp
+++ b/src/osgEarthDrivers/engine_rex/LayerDrawable.cpp
@@ -35,7 +35,8 @@ _visibleLayer(0L),
 _imageLayer(0L),
 _patchLayer(0L),
 _clearOsgState(false),
-_draw(true)
+_draw(true),
+_tileBatchId(0)
 {
     setDataVariance(DYNAMIC);
     setUseDisplayList(false);

--- a/src/osgEarthDrivers/engine_rex/TileNodeRegistry.cpp
+++ b/src/osgEarthDrivers/engine_rex/TileNodeRegistry.cpp
@@ -38,7 +38,8 @@ TileNodeRegistry::TileNodeRegistry(const std::string& name) :
 _name              ( name ),
 _revisioningEnabled( false ),
 _notifyNeighbors   ( false ),
-_firstLOD          ( 0u )
+_firstLOD          ( 0u ),
+_clock             ( NULL )
 {
     _tracker.push_front(SENTRY_VALUE);
     _sentryptr = _tracker.begin();

--- a/src/osgEarthDrivers/engine_rex/Unloader.cpp
+++ b/src/osgEarthDrivers/engine_rex/Unloader.cpp
@@ -35,7 +35,8 @@ _cacheSize(0u),
 _maxAge(0.1),
 _minRange(0.0f),
 _maxTilesToUnloadPerFrame(~0),
-_frameLastUpdated(0u)
+_frameLastUpdated(0u),
+_clock(NULL)
 {
     ADJUST_UPDATE_TRAV_COUNT(this, +1);
 }

--- a/src/osgEarthDrivers/kml/rapidxml.hpp
+++ b/src/osgEarthDrivers/kml/rapidxml.hpp
@@ -658,6 +658,8 @@ namespace rapidxml
             : m_name(0)
             , m_value(0)
             , m_parent(0)
+            , m_name_size(0)
+            , m_value_size(0)
         {
         }
 

--- a/src/osgEarthSplat/GroundCoverLayer.cpp
+++ b/src/osgEarthSplat/GroundCoverLayer.cpp
@@ -743,6 +743,10 @@ GroundCoverLayer::Renderer::UniformState::UniformState()
     _A2CUL = -1;
     _tileCounter = 0;
     _numInstances1D = 0;
+    for (int i = 0; i < 5; ++i)
+    {
+       _computeData[i] = 0.0f;
+    }
 }
 
 GroundCoverLayer::Renderer::Renderer(GroundCoverLayer* layer)


### PR DESCRIPTION
+ Check index before using index
  + BoundaryUtil::findHull
+ Initialize variables
  + osgearth_clamp::App
  + osgearth_exportgroundcover::App
  + osgearth_magnify::App
  + ActionOption
  + InstanceCloud::InstancingData::InstancingData
  + Layer::Layer
  + OGR::OGRFeatureCursor::OGRFeatureCursor
  + SpatialReference::key
  + TileRasterizer::RenderOperation::RenderOperation
  + WMS::Driver::Driver
  + DrawTileCommand
  + LayerDrawable::LayerDrawable
  + TileNodeRegistry::TileNodeRegistry
  + UnloaderGroup::UnloaderGroup
  + xml_base
  + GroundCoverLayer::Renderer::UniformState::UniformState
+ Copy constructor should copy all variables
  + EarthManipulator::EarthManipulator
+ Use ref_ptr to avoid leaking memory on early return
  + MapNodeHelper::load
+ Prefer initializer vs assignment in constructor
  + DataExtent::DataExtent
  + TileImage::TileImage
+ Switch does not cover all cases
  + HeightFieldUtils::getHeightAtPixel
+ Use unsigned int for 1 bit variables for true/false
  + Value::allocated
+ Removed unused variables
  + GeoLocator _x0, _y0, _x1, _y1
+ Guard against self-assignment
  + Style::operator =
+ Avoid checking the same condition twice
  + ThreeDTileNode::unloadContent
+ Base class function signature differs from derived class
  + WindDrawable
+ Unconditional break within while loop
  + AerodromeFactory::createBoundaryNodes
+ Code exists after return
  + BuildingLayer::openImplementation
+
